### PR TITLE
Return index.html if path is directory

### DIFF
--- a/src/file_utils.adb
+++ b/src/file_utils.adb
@@ -30,4 +30,12 @@ package body File_Utils is
          File_String_IO.Close (File => The_File);
          raise File_String_IO.Device_Error;
    end Read;
+
+   function Is_Dir (Path : String) return Boolean is
+      use type Ada.Directories.File_Kind;
+   begin
+      return Ada.Directories.Exists (Path)
+             and then Ada.Directories.Kind (Path) = Ada.Directories.Directory;
+   end Is_Dir;
+
 end File_Utils;

--- a/src/file_utils.ads
+++ b/src/file_utils.ads
@@ -1,3 +1,4 @@
 package File_Utils is
    function Read (File_Name : String) return String;
+   function Is_Dir (Path : String) return Boolean;
 end File_Utils;

--- a/src/transaction_handlers.adb
+++ b/src/transaction_handlers.adb
@@ -23,7 +23,11 @@ package body Transaction_Handlers is
                CFirst : constant Positive := Context'First;
                Path   : constant String := Context (CFirst .. First) & URI;
             begin
-               return Make_Response (OK, File_Utils.Read (Path));
+               if File_Utils.Is_Dir (Path) then
+                  return Make_Response (OK, File_Utils.Read (Path & "/index.html"));
+               else
+                  return Make_Response (OK, File_Utils.Read (Path));
+               end if;
             end;
 
          when POST | PUT | DELETE | HEAD | OPTIONS | TRACE =>


### PR DESCRIPTION
Currently if the path points to a directory the server answers with resource not found as it cannot open the file. This change checks if the path is a directory and appends `/index.html` if so.